### PR TITLE
fix formatting of Key Partners

### DIFF
--- a/Key_Partners.md
+++ b/Key_Partners.md
@@ -1,9 +1,9 @@
 # Key Partners
-      -Airbnb+local hotels:Would provide vital exposure to the tourism industry.
-      -Local bars, restaurants, and shopping:Would provide destination points scattered throughout a city (as opposed to targeting specific office sites, for example).
-      -Local governments:Would need regulatory approval (and certain legislation to ensure no liability).
-      -Sporitng Goods stores:Could provide the initial transportation forms; ultimately, we would want to build and brand our own transportation modes, especially afterlearning what is most effective (bikes, scooters, tollerblades, etc.).
-      -Local tech start-ups:Provide exposure (word of mouth) to residents most likely to fit into our target demographic.
-      -Paypal and other cashless payment services:Would reduce costs and add a measure of autgenticity.
-      -For initial phases:Universities, airports, big businesses; specifically student organizations
-      -Instacart, Lyft, Doordash, Postmates, and Grubhub:Work together to better each other.
+- **Airbnb+local hotels:** Would provide vital exposure to the tourism industry.
+- **Local bars, restaurants, and shopping:** Would provide destination points scattered throughout a city (as opposed to targeting specific office sites, for example).
+- **Local governments:** Would need regulatory approval (and certain legislation to ensure no liability).
+- **Sporitng Goods stores:** Could provide the initial transportation forms; ultimately, we would want to build and brand our own transportation modes, especially afterlearning what is most effective (bikes, scooters, tollerblades, etc.).
+- **Local tech start-ups:** Provide exposure (word of mouth) to residents most likely to fit into our target demographic.
+- **Paypal and other cashless payment services:** Would reduce costs and add a measure of autgenticity.
+- **For initial phases:** Universities, airports, big businesses; specifically student organizations
+- **Instacart, Lyft, Doordash, Postmates, and Grubhub:** Work together to better each other.


### PR DESCRIPTION
It looks like the formatting may have been messed up when copy-pasting the text to GitHub.

- Remove the spaces from the beginning of the line and Markdown will treat it as regular text.
- Add a space after the hyphen and Markdown will treat it as a bullet point.
- Add two asterisks before and after some text to make it bold.